### PR TITLE
docs: correct article usage with "Kurrent"

### DIFF
--- a/kurrentdb/client.go
+++ b/kurrentdb/client.go
@@ -19,13 +19,13 @@ import (
 )
 
 // Client Represents a client to a single node. A client instance maintains a full duplex communication to KurrentDB.
-// Many threads can use an KurrentDB client at the same time or a single thread can make many asynchronous requests.
+// Many threads can use a KurrentDB client at the same time or a single thread can make many asynchronous requests.
 type Client struct {
 	grpcClient *grpcClient
 	config     *Configuration
 }
 
-// NewClient Creates a gRPC client to an KurrentDB database.
+// NewClient Creates a gRPC client to a KurrentDB database.
 func NewClient(configuration *Configuration) (*Client, error) {
 	if err := configuration.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)

--- a/kurrentdb/operations.go
+++ b/kurrentdb/operations.go
@@ -1,6 +1,6 @@
 package kurrentdb
 
-// ServerVersion Represents the version of an KurrentDB node.
+// ServerVersion Represents the version of a KurrentDB node.
 type ServerVersion struct {
 	Major int
 	Minor int


### PR DESCRIPTION
This PR addresses grammatical issues that occurred during the rebranding from "Event Store" to "Kurrent". The main issue was incorrect article usage - using "an KurrentDB" instead of "a KurrentDB" since "Kurrent" starts with a consonant sound.