### PR TITLE
fix possible segfault

### DIFF
--- a/kurrentdb/subscriptions.go
+++ b/kurrentdb/subscriptions.go
@@ -107,11 +107,11 @@ func (sub *Subscription) Recv() *SubscriptionEvent {
 					if wire.StreamRevision != nil {
 						caughtUp.StreamRevision = new(uint64)
 						*caughtUp.StreamRevision = uint64(wire.GetStreamRevision())
-					} else {
+					} else if pos := wire.GetPosition(); pos != nil {
 						caughtUp.Position = new(Position)
 						*caughtUp.Position = Position{
-							Commit:  wire.GetPosition().CommitPosition,
-							Prepare: wire.GetPosition().PreparePosition,
+							Commit:  pos.CommitPosition,
+							Prepare: pos.PreparePosition,
 						}
 					}
 				}


### PR DESCRIPTION
When subscribing to a stream that doesn't exist, you get a caught up message with no stream revision or position.

There is an if/else that needs to be an if/elseif to handle this possibility.