### PR TITLE
Add OAuth bearer token authentication and a credentials provider

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,3 +71,39 @@ jobs:
 
       - name: Run Go Tests
         run: go test --count=1 -v ./test -run Test${{ matrix.test }}
+
+  oauth-test:
+    needs: load_configuration
+    name: OAuth Test
+    timeout-minutes: 10
+
+    runs-on: ubuntu-latest
+    # OAuth is a licensed feature; the steps are skipped (job stays green) when
+    # the license secret is unavailable, e.g. on pull requests from forks.
+    env:
+      KURRENTDB_LICENSE_KEY: ${{ secrets.KURRENTDB_TEST_LICENSE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go_version }}
+
+      - name: Login to Cloudsmith
+        if: env.KURRENTDB_LICENSE_KEY != ''
+        uses: docker/login-action@v3
+        with:
+          registry: docker.kurrent.io
+          username: ${{ secrets.CLOUDSMITH_CICD_USER }}
+          password: ${{ secrets.CLOUDSMITH_CICD_TOKEN }}
+
+      - name: Start OAuth stack
+        if: env.KURRENTDB_LICENSE_KEY != ''
+        run: make start-oauth
+        env:
+          KURRENTDB_DOCKER_REGISTRY: ${{ needs.load_configuration.outputs.registry }}
+          KURRENTDB_DOCKER_IMAGE: ${{ needs.load_configuration.outputs.image }}
+          KURRENTDB_DOCKER_TAG: ${{ needs.load_configuration.outputs.tag }}
+
+      - name: Run OAuth tests
+        if: env.KURRENTDB_LICENSE_KEY != ''
+        run: go test --count=1 -v ./test -run TestOAuthAuthenticationSuite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,8 +78,11 @@ jobs:
     timeout-minutes: 10
 
     runs-on: ubuntu-latest
-    # OAuth is a licensed feature; the steps are skipped (job stays green) when
-    # the license secret is unavailable, e.g. on pull requests from forks.
+    # OAuth e2e runs only on the `ci` runtime: that image ships the licensed
+    # OAuth plugin and the kurrentd entrypoint the stack expects (the lts /
+    # previous-lts images are EventStoreDB-branded with a different layout). The
+    # steps are also skipped when the license secret is unavailable, e.g. on
+    # pull requests from forks, so the job stays green.
     env:
       KURRENTDB_LICENSE_KEY: ${{ secrets.KURRENTDB_TEST_LICENSE_KEY }}
     steps:
@@ -89,7 +92,7 @@ jobs:
           go-version: ${{ inputs.go_version }}
 
       - name: Login to Cloudsmith
-        if: env.KURRENTDB_LICENSE_KEY != ''
+        if: inputs.runtime == 'ci' && env.KURRENTDB_LICENSE_KEY != ''
         uses: docker/login-action@v3
         with:
           registry: docker.kurrent.io
@@ -97,7 +100,7 @@ jobs:
           password: ${{ secrets.CLOUDSMITH_CICD_TOKEN }}
 
       - name: Start OAuth stack
-        if: env.KURRENTDB_LICENSE_KEY != ''
+        if: inputs.runtime == 'ci' && env.KURRENTDB_LICENSE_KEY != ''
         run: make start-oauth
         env:
           KURRENTDB_DOCKER_REGISTRY: ${{ needs.load_configuration.outputs.registry }}
@@ -105,5 +108,5 @@ jobs:
           KURRENTDB_DOCKER_TAG: ${{ needs.load_configuration.outputs.tag }}
 
       - name: Run OAuth tests
-        if: env.KURRENTDB_LICENSE_KEY != ''
+        if: inputs.runtime == 'ci' && env.KURRENTDB_LICENSE_KEY != ''
         run: go test --count=1 -v ./test -run TestOAuthAuthenticationSuite

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,15 @@ start-kurrentdb:
 stop-kurrentdb:
 	@docker compose down -v --remove-orphans
 
+.PHONY: start-oauth
+start-oauth: ## Start the OAuth stack (Keycloak + an OAuth KurrentDB node). Requires KURRENTDB_LICENSE_KEY.
+	@docker compose -f docker-compose.oauth.yml up -d --wait
+	@docker compose -f docker-compose.oauth.yml ps
+
+.PHONY: stop-oauth
+stop-oauth:
+	@KURRENTDB_LICENSE_KEY=unset docker compose -f docker-compose.oauth.yml down -v --remove-orphans
+
 .PHONY: test
 test: ## Run tests
 	go test --count=1 -v ./test

--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ with:
 
 These variables combine to form the complete image reference used during testing.
 
+### Running the OAuth tests
+
+The OAuth authentication tests run against a separate stack (a Keycloak identity
+provider plus a KurrentDB node configured for OAuth) defined in
+`docker-compose.oauth.yml`. They are kept apart from the main suite because OAuth
+is a licensed feature: the node needs a license key, and the image must include
+the OAuth plugin. The `TestOAuthAuthenticationSuite` suite skips when the stack
+is not running, so it does not affect the default `make test` run.
+
+Set a license key, then start the stack and run the suite:
+
+```bash
+export KURRENTDB_LICENSE_KEY=<your-license-key>
+make start-oauth
+go test ./test -run TestOAuthAuthenticationSuite
+make stop-oauth
+```
+
+The `KURRENTDB_DOCKER_*` variables select the image as above; it must be one that
+ships the OAuth plugin. These tests are not part of the default CI matrix —
+enabling them there requires a license-key secret, a plugin-capable image, and a
+matrix entry that runs `make start-oauth` before the suite.
+
 ## More resources
 
 - [Release notes](https://kurrent.io/blog/release-notes)

--- a/docker-compose.oauth.yml
+++ b/docker-compose.oauth.yml
@@ -1,0 +1,79 @@
+# OAuth integration-test stack: a Keycloak identity provider plus a single
+# KurrentDB node configured for OAuth authentication. Kept separate from the
+# main docker-compose.yml because OAuth is a licensed feature - the node needs
+# KURRENTDB_LICENSE_KEY to start, so it must not be part of the default
+# `make start-kurrentdb` flow. Bring it up with `make start-oauth`.
+name: tests-oauth
+
+services:
+  keycloak:
+    container_name: keycloak
+    image: quay.io/keycloak/keycloak:24.0
+    command: start --import-realm
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./oauth/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
+      - ./certs:/certs
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTPS_CERTIFICATE_FILE: /certs/node1/node.crt
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /certs/node1/node.key
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: "8443"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "false"
+      KC_HEALTH_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/8443"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 60s
+
+  single-oauth:
+    container_name: single-oauth
+    # The image must include the OAuth plugin (a licensed feature). The default
+    # is the public latest image, which carries it; CI overrides these vars to
+    # the registry/tag under test.
+    image: ${KURRENTDB_DOCKER_REGISTRY:-kurrentplatform}/${KURRENTDB_DOCKER_IMAGE:-kurrentdb}:${KURRENTDB_DOCKER_TAG:-latest}
+    # Root so the entrypoint can install the test CA into the OS trust store.
+    user: "0"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    # Lets the node reach the Keycloak issuer at https://localhost:8443 (the
+    # same host the token's issuer claim uses) via the published host port.
+    extra_hosts:
+      - "localhost:host-gateway"
+    environment:
+      EVENTSTORE_CERTIFICATE_FILE: "/etc/kurrentdb/certs/node1/node.crt"
+      EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE: "/etc/kurrentdb/certs/node1/node.key"
+      EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH: "/etc/kurrentdb/certs/ca"
+      EVENTSTORE_ADVERTISE_HOST_TO_CLIENT_AS: "localhost"
+      EVENTSTORE_ADVERTISE_NODE_PORT_TO_CLIENT_AS: "2116"
+      EVENTSTORE_ALLOW_UNKNOWN_OPTIONS: "true"
+      EVENTSTORE_AUTHENTICATION_TYPE: "oauth"
+      EVENTSTORE_AUTHENTICATION_CONFIG: "/etc/kurrentdb/kurrentdb.conf"
+      EVENTSTORE_LICENSING__LICENSE_KEY: "${KURRENTDB_LICENSE_KEY:?OAuth tests require a KURRENTDB_LICENSE_KEY}"
+    # The OAuth plugin validates the issuer over HTTPS using the OS trust store
+    # (not the KurrentDB trusted-roots path), so install the test CA before
+    # starting the node.
+    entrypoint: >
+      sh -c '
+      cp /etc/kurrentdb/certs/ca/ca.crt /usr/local/share/ca-certificates/local-ca.crt;
+      update-ca-certificates;
+      exec /opt/kurrentdb/kurrentd;
+      '
+    ports:
+      - "2116:2113"
+    volumes:
+      - ./certs:/etc/kurrentdb/certs
+      - ./oauth/oauth.conf:/etc/kurrentdb/kurrentdb.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sSfk https://localhost:2113/health/live || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 60s

--- a/kurrentdb/client.go
+++ b/kurrentdb/client.go
@@ -919,7 +919,7 @@ func (client *Client) replayParkedMessages(ctx context.Context, streamName strin
 		return persistentSubscriptionClient.replayParkedMessages(ctx, client.config, handle, finalStreamName, groupName, &options)
 	}
 
-	return client.httpReplayParkedMessages(streamName, groupName, options)
+	return client.httpReplayParkedMessages(ctx, streamName, groupName, options)
 }
 
 // ListAllPersistentSubscriptions Lists all persistent subscriptions regardless of which stream they are on.
@@ -954,10 +954,10 @@ func (client *Client) listPersistentSubscriptionsInternal(ctx context.Context, s
 	}
 
 	if streamName != nil {
-		return client.httpListPersistentSubscriptionsForStream(*streamName, options)
+		return client.httpListPersistentSubscriptionsForStream(ctx, *streamName, options)
 	}
 
-	return client.httpListAllPersistentSubscriptions(options)
+	return client.httpListAllPersistentSubscriptions(ctx, options)
 }
 
 // GetPersistentSubscriptionInfo Gets the info for a specific persistent subscription to a stream
@@ -991,7 +991,7 @@ func (client *Client) getPersistentSubscriptionInfoInternal(ctx context.Context,
 		*streamName = "$all"
 	}
 
-	return client.httpGetPersistentSubscriptionInfo(*streamName, groupName, options)
+	return client.httpGetPersistentSubscriptionInfo(ctx, *streamName, groupName, options)
 }
 
 // RestartPersistentSubscriptionSubsystem Restarts the persistent subscription subsystem on the server.
@@ -1006,7 +1006,7 @@ func (client *Client) RestartPersistentSubscriptionSubsystem(ctx context.Context
 		return persistentClient.restartSubsystem(ctx, client.config, handle, &options)
 	}
 
-	return client.httpRestartSubsystem(options)
+	return client.httpRestartSubsystem(ctx, options)
 }
 
 func readInternal(

--- a/kurrentdb/configuration.go
+++ b/kurrentdb/configuration.go
@@ -1,6 +1,7 @@
 package kurrentdb
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	url2 "net/url"
@@ -89,6 +90,42 @@ type Configuration struct {
 
 	// Logging abstraction used by the client.
 	Logger LoggingFunc
+
+	// CredentialsProvider, when set, supplies the credentials for each request,
+	// e.g. a refresh-aware OAuth/OIDC token source. See CredentialsProvider for
+	// the invocation contract. It takes precedence over Username/Password. Like
+	// Username/Password, it is not used when TLS is disabled, as credentials are
+	// never sent over an insecure channel.
+	CredentialsProvider CredentialsProvider
+}
+
+// staticCredentials returns the static username/password credentials configured
+// on the client, or nil when both are not set.
+func (conf *Configuration) staticCredentials() *Credentials {
+	if conf.Username != "" && conf.Password != "" {
+		return &Credentials{Login: conf.Username, Password: conf.Password}
+	}
+
+	return nil
+}
+
+// resolveRequestCredentials selects the credentials for a request by precedence:
+// per-call credentials, then the CredentialsProvider, then static
+// username/password. It returns nil credentials when none apply or when TLS is
+// disabled, as credentials are never sent over an insecure channel.
+func (conf *Configuration) resolveRequestCredentials(ctx context.Context, perCall *Credentials) (*Credentials, error) {
+	if conf.DisableTLS {
+		return nil, nil
+	}
+
+	switch {
+	case perCall != nil:
+		return perCall, nil
+	case conf.CredentialsProvider != nil:
+		return conf.CredentialsProvider(ctx)
+	default:
+		return conf.staticCredentials(), nil
+	}
 }
 
 func (conf *Configuration) applyLogger(level LogLevel, format string, args ...interface{}) {

--- a/kurrentdb/credentials.go
+++ b/kurrentdb/credentials.go
@@ -1,9 +1,50 @@
 package kurrentdb
 
-// Credentials holds a login and a password for authenticated requests.
+import (
+	"context"
+	"encoding/base64"
+)
+
+// CredentialsProvider resolves the credentials for an outbound request. It is
+// invoked once per request, so a provider can return a cached token until it
+// nears expiry and then rotate it, and the new token is picked up transparently
+// across reconnects. It is called on the request's goroutine and may run
+// concurrently for in-flight requests, so it must be safe for concurrent use,
+// reasonably fast (it blocks the request until it returns), and should honour
+// the supplied context. Returning nil credentials sends the request
+// unauthenticated.
+type CredentialsProvider func(context.Context) (*Credentials, error)
+
+// Credentials holds the authentication used for requests: either a
+// login/password pair (HTTP Basic) or a bearer token (OAuth/JWT). A bearer
+// token, when set, takes precedence over the login and password.
 type Credentials struct {
 	// User's login.
 	Login string
 	// User's password.
 	Password string
+	// BearerToken authenticates via an `Authorization: Bearer <token>` header,
+	// e.g. an OAuth/OIDC access token. When set it takes precedence over Login
+	// and Password. Bearer tokens are programmatic-only: they cannot be supplied
+	// through a connection string.
+	BearerToken string
+}
+
+// authorizationHeader renders the credentials as the value of an
+// `Authorization` header (`"Bearer ..."` or `"Basic ..."`), or an empty string
+// when no credentials are set.
+func (creds *Credentials) authorizationHeader() string {
+	if creds == nil {
+		return ""
+	}
+
+	if creds.BearerToken != "" {
+		return "Bearer " + creds.BearerToken
+	}
+
+	if creds.Login == "" && creds.Password == "" {
+		return ""
+	}
+
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(creds.Login+":"+creds.Password))
 }

--- a/kurrentdb/credentials_test.go
+++ b/kurrentdb/credentials_test.go
@@ -1,0 +1,228 @@
+package kurrentdb
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type fakeOptions struct{ creds *Credentials }
+
+func (fakeOptions) kind() operationKind         { return regularOperation }
+func (o fakeOptions) credentials() *Credentials { return o.creds }
+func (fakeOptions) deadline() *time.Duration    { return nil }
+func (fakeOptions) requiresLeader() bool        { return false }
+
+func headerFrom(t *testing.T, creds credentials.PerRPCCredentials) string {
+	t.Helper()
+	if creds == nil {
+		return ""
+	}
+	md, err := creds.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	return md["Authorization"]
+}
+
+func TestCredentialsAuthorizationHeader(t *testing.T) {
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:changeit"))
+
+	for _, tc := range []struct {
+		name  string
+		creds *Credentials
+		want  string
+	}{
+		{"nil", nil, ""},
+		{"empty", &Credentials{}, ""},
+		{"basic", &Credentials{Login: "admin", Password: "changeit"}, basic},
+		{"bearer", &Credentials{BearerToken: "abc.def"}, "Bearer abc.def"},
+		{"bearer wins over basic", &Credentials{Login: "admin", Password: "changeit", BearerToken: "abc.def"}, "Bearer abc.def"},
+		{"login only", &Credentials{Login: "admin"}, "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.creds.authorizationHeader())
+		})
+	}
+}
+
+func TestStaticAuthPerRPCCredentials(t *testing.T) {
+	t.Run("attaches the rendered header", func(t *testing.T) {
+		creds := staticAuthPerRPCCredentials(&Credentials{BearerToken: "tok"})
+		md, err := creds.GetRequestMetadata(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"Authorization": "Bearer tok"}, md)
+	})
+
+	t.Run("no header when credentials are empty", func(t *testing.T) {
+		creds := staticAuthPerRPCCredentials(&Credentials{})
+		md, err := creds.GetRequestMetadata(context.Background())
+		require.NoError(t, err)
+		assert.Nil(t, md)
+	})
+
+	t.Run("requires transport security", func(t *testing.T) {
+		assert.True(t, staticAuthPerRPCCredentials(&Credentials{}).RequireTransportSecurity())
+	})
+}
+
+func TestProviderAuthPerRPCCredentials(t *testing.T) {
+	t.Run("resolves the provider on every call", func(t *testing.T) {
+		calls := 0
+		creds := providerAuthPerRPCCredentials(func(context.Context) (*Credentials, error) {
+			calls++
+			return &Credentials{BearerToken: "tok"}, nil
+		})
+
+		for i := 0; i < 3; i++ {
+			md, err := creds.GetRequestMetadata(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, map[string]string{"Authorization": "Bearer tok"}, md)
+		}
+		assert.Equal(t, 3, calls, "provider must run once per RPC so refreshed tokens are picked up")
+	})
+
+	t.Run("propagates the provider error", func(t *testing.T) {
+		boom := errors.New("token fetch failed")
+		creds := providerAuthPerRPCCredentials(func(context.Context) (*Credentials, error) {
+			return nil, boom
+		})
+		md, err := creds.GetRequestMetadata(context.Background())
+		assert.Nil(t, md)
+		assert.ErrorIs(t, err, boom)
+	})
+
+	t.Run("no header when the provider returns nil credentials", func(t *testing.T) {
+		creds := providerAuthPerRPCCredentials(func(context.Context) (*Credentials, error) {
+			return nil, nil
+		})
+		md, err := creds.GetRequestMetadata(context.Background())
+		require.NoError(t, err)
+		assert.Nil(t, md)
+	})
+}
+
+func TestClientPerRPCCredentials(t *testing.T) {
+	provider := func(context.Context) (*Credentials, error) { return &Credentials{BearerToken: "tok"}, nil }
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:changeit"))
+
+	t.Run("nil over an insecure channel", func(t *testing.T) {
+		assert.Nil(t, clientPerRPCCredentials(Configuration{DisableTLS: true, CredentialsProvider: provider}))
+		assert.Nil(t, clientPerRPCCredentials(Configuration{DisableTLS: true, Username: "admin", Password: "changeit"}))
+	})
+
+	t.Run("provider takes precedence over static", func(t *testing.T) {
+		creds := clientPerRPCCredentials(Configuration{CredentialsProvider: provider, Username: "admin", Password: "changeit"})
+		assert.Equal(t, "Bearer tok", headerFrom(t, creds))
+	})
+
+	t.Run("static basic when only username/password", func(t *testing.T) {
+		assert.Equal(t, basic, headerFrom(t, clientPerRPCCredentials(Configuration{Username: "admin", Password: "changeit"})))
+	})
+
+	t.Run("nil when nothing is set", func(t *testing.T) {
+		assert.Nil(t, clientPerRPCCredentials(Configuration{}))
+	})
+}
+
+func TestConfigureGrpcCallCredentialPrecedence(t *testing.T) {
+	conf := &Configuration{}
+	clientCreds := providerAuthPerRPCCredentials(func(context.Context) (*Credentials, error) {
+		return &Credentials{BearerToken: "client"}, nil
+	})
+
+	extract := func(opts []grpc.CallOption) credentials.PerRPCCredentials {
+		for _, o := range opts {
+			if c, ok := o.(grpc.PerRPCCredsCallOption); ok {
+				return c.Creds
+			}
+		}
+		return nil
+	}
+
+	t.Run("per-call credentials override the client provider", func(t *testing.T) {
+		opts, _, cancel := configureGrpcCall_(context.Background(), conf, fakeOptions{creds: &Credentials{BearerToken: "percall"}}, nil, clientCreds, true)
+		defer cancel()
+		assert.Equal(t, "Bearer percall", headerFrom(t, extract(opts)))
+	})
+
+	t.Run("client provider used when there are no per-call credentials", func(t *testing.T) {
+		opts, _, cancel := configureGrpcCall_(context.Background(), conf, fakeOptions{}, nil, clientCreds, true)
+		defer cancel()
+		assert.Equal(t, "Bearer client", headerFrom(t, extract(opts)))
+	})
+
+	t.Run("per-call basic credentials render a Basic header", func(t *testing.T) {
+		basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:changeit"))
+		opts, _, cancel := configureGrpcCall_(context.Background(), conf, fakeOptions{creds: &Credentials{Login: "admin", Password: "changeit"}}, nil, clientCreds, true)
+		defer cancel()
+		assert.Equal(t, basic, headerFrom(t, extract(opts)))
+	})
+
+	t.Run("per-call credentials are dropped over an insecure channel", func(t *testing.T) {
+		insecure := &Configuration{DisableTLS: true}
+		opts, _, cancel := configureGrpcCall_(context.Background(), insecure, fakeOptions{creds: &Credentials{BearerToken: "percall"}}, nil, nil, true)
+		defer cancel()
+		assert.Nil(t, extract(opts))
+	})
+}
+
+func TestResolveRequestCredentials(t *testing.T) {
+	ctx := context.Background()
+	provider := func(context.Context) (*Credentials, error) { return &Credentials{BearerToken: "prov"}, nil }
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:changeit"))
+
+	t.Run("nil over an insecure channel", func(t *testing.T) {
+		conf := &Configuration{DisableTLS: true, CredentialsProvider: provider, Username: "admin", Password: "changeit"}
+		creds, err := conf.resolveRequestCredentials(ctx, &Credentials{BearerToken: "percall"})
+		require.NoError(t, err)
+		assert.Nil(t, creds)
+	})
+
+	t.Run("per-call takes precedence over provider and static", func(t *testing.T) {
+		conf := &Configuration{CredentialsProvider: provider, Username: "admin", Password: "changeit"}
+		creds, err := conf.resolveRequestCredentials(ctx, &Credentials{BearerToken: "percall"})
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer percall", creds.authorizationHeader())
+	})
+
+	t.Run("provider takes precedence over static", func(t *testing.T) {
+		conf := &Configuration{CredentialsProvider: provider, Username: "admin", Password: "changeit"}
+		creds, err := conf.resolveRequestCredentials(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer prov", creds.authorizationHeader())
+	})
+
+	t.Run("static basic when only username/password", func(t *testing.T) {
+		conf := &Configuration{Username: "admin", Password: "changeit"}
+		creds, err := conf.resolveRequestCredentials(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, basic, creds.authorizationHeader())
+	})
+
+	t.Run("username without password is not used (parity with the gRPC gate)", func(t *testing.T) {
+		conf := &Configuration{Username: "admin"}
+		creds, err := conf.resolveRequestCredentials(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, creds)
+	})
+
+	t.Run("provider error propagates", func(t *testing.T) {
+		boom := errors.New("token fetch failed")
+		conf := &Configuration{CredentialsProvider: func(context.Context) (*Credentials, error) { return nil, boom }}
+		_, err := conf.resolveRequestCredentials(ctx, nil)
+		assert.ErrorIs(t, err, boom)
+	})
+
+	t.Run("provider returning nil credentials yields nil", func(t *testing.T) {
+		conf := &Configuration{CredentialsProvider: func(context.Context) (*Credentials, error) { return nil, nil }}
+		creds, err := conf.resolveRequestCredentials(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, creds)
+	})
+}

--- a/kurrentdb/endpoint.go
+++ b/kurrentdb/endpoint.go
@@ -71,6 +71,24 @@ func ParseEndPoint(s string) (*EndPoint, error) {
 	return endpoint, nil
 }
 
+// clientPerRPCCredentials builds the client-level RPC credentials. A credentials
+// provider takes precedence over static username/password. Credentials are never
+// sent over an insecure channel.
+func clientPerRPCCredentials(config Configuration) credentials.PerRPCCredentials {
+	if config.DisableTLS {
+		return nil
+	}
+
+	switch {
+	case config.CredentialsProvider != nil:
+		return providerAuthPerRPCCredentials(config.CredentialsProvider)
+	case config.staticCredentials() != nil:
+		return staticAuthPerRPCCredentials(config.staticCredentials())
+	default:
+		return nil
+	}
+}
+
 func newGrpcClient(config Configuration) *grpcClient {
 	channel := make(chan msg)
 	closeFlag := new(int32)
@@ -82,17 +100,11 @@ func newGrpcClient(config Configuration) *grpcClient {
 
 	go connectionStateMachine(config, closeFlag, channel, &logger)
 
-	// Maybe construct RPC credentials from client config.
-	var perRPCCredentials credentials.PerRPCCredentials
-	if config.Username != "" && config.Password != "" && !config.DisableTLS {
-		perRPCCredentials = newBasicAuthPerRPCCredentials(config.Username, config.Password)
-	}
-
 	return &grpcClient{
 		channel:           channel,
 		closeFlag:         closeFlag,
 		once:              new(sync.Once),
 		logger:            &logger,
-		perRPCCredentials: perRPCCredentials,
+		perRPCCredentials: clientPerRPCCredentials(config),
 	}
 }

--- a/kurrentdb/impl.go
+++ b/kurrentdb/impl.go
@@ -3,7 +3,6 @@ package kurrentdb
 import (
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -456,22 +455,53 @@ func getSupportedMethods(ctx context.Context, conf *Configuration, conn *grpc.Cl
 	return &info, nil
 }
 
-func newBasicAuthPerRPCCredentials(username, password string) *basicAuthPerRPCCredentials {
-	authorization := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
-	headers := map[string]string{"Authorization": authorization}
-	return &basicAuthPerRPCCredentials{headers: headers}
+// authPerRPCCredentials attaches an "Authorization" header to every RPC. The
+// header is resolved per call so refresh-aware credential providers rotate
+// tokens transparently across reconnects.
+type authPerRPCCredentials struct {
+	resolve func(ctx context.Context) (string, error)
 }
 
-type basicAuthPerRPCCredentials struct {
-	headers map[string]string
+var _ credentials.PerRPCCredentials = authPerRPCCredentials{}
+
+func (c authPerRPCCredentials) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
+	header, err := c.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if header == "" {
+		return nil, nil
+	}
+
+	return map[string]string{"Authorization": header}, nil
 }
 
-func (b *basicAuthPerRPCCredentials) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
-	return b.headers, nil
-}
-
-func (*basicAuthPerRPCCredentials) RequireTransportSecurity() bool {
+func (authPerRPCCredentials) RequireTransportSecurity() bool {
 	return true
+}
+
+// staticAuthPerRPCCredentials sends the same credentials on every RPC.
+func staticAuthPerRPCCredentials(creds *Credentials) authPerRPCCredentials {
+	header := creds.authorizationHeader()
+	return authPerRPCCredentials{resolve: func(context.Context) (string, error) {
+		return header, nil
+	}}
+}
+
+// providerAuthPerRPCCredentials resolves credentials from the provider on each
+// RPC, so refresh-aware token sources rotate transparently.
+func providerAuthPerRPCCredentials(provider CredentialsProvider) authPerRPCCredentials {
+	return authPerRPCCredentials{resolve: func(ctx context.Context) (string, error) {
+		creds, err := provider(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve credentials: %w", err)
+		}
+
+		// A provider returning nil credentials sends the request
+		// unauthenticated; authorizationHeader is nil-safe and returns "".
+		return creds.authorizationHeader(), nil
+	}}
 }
 
 func allowedNodeState() []gossipApi.MemberInfo_VNodeState {

--- a/kurrentdb/options.go
+++ b/kurrentdb/options.go
@@ -46,7 +46,7 @@ func configureGrpcCall_(ctx context.Context, conf *Configuration, options option
 
 	// Maybe use RPC credentials from client method options instead of RPC credentials from client config.
 	if options.credentials() != nil && !conf.DisableTLS {
-		perRPCCredentials = newBasicAuthPerRPCCredentials(options.credentials().Login, options.credentials().Password)
+		perRPCCredentials = staticAuthPerRPCCredentials(options.credentials())
 	}
 
 	// Maybe append RPC credentials to gRPC call options.

--- a/kurrentdb/persistent_subscription_http_client.go
+++ b/kurrentdb/persistent_subscription_http_client.go
@@ -1,6 +1,7 @@
 package kurrentdb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,8 +11,8 @@ import (
 	"strings"
 )
 
-func (client *Client) httpListAllPersistentSubscriptions(options ListPersistentSubscriptionsOptions) ([]PersistentSubscriptionInfo, error) {
-	body, err := client.httpExecute("GET", "/subscriptions", options.Authenticated, nil)
+func (client *Client) httpListAllPersistentSubscriptions(ctx context.Context, options ListPersistentSubscriptionsOptions) ([]PersistentSubscriptionInfo, error) {
+	body, err := client.httpExecute(ctx, "GET", "/subscriptions", options.Authenticated, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +38,8 @@ func (client *Client) httpListAllPersistentSubscriptions(options ListPersistentS
 	return infos, nil
 }
 
-func (client *Client) httpListPersistentSubscriptionsForStream(streamName string, options ListPersistentSubscriptionsOptions) ([]PersistentSubscriptionInfo, error) {
-	body, err := client.httpExecute("GET", fmt.Sprintf("/subscriptions/%s", url.PathEscape(streamName)), options.Authenticated, nil)
+func (client *Client) httpListPersistentSubscriptionsForStream(ctx context.Context, streamName string, options ListPersistentSubscriptionsOptions) ([]PersistentSubscriptionInfo, error) {
+	body, err := client.httpExecute(ctx, "GET", fmt.Sprintf("/subscriptions/%s", url.PathEscape(streamName)), options.Authenticated, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +65,8 @@ func (client *Client) httpListPersistentSubscriptionsForStream(streamName string
 	return infos, nil
 }
 
-func (client *Client) httpGetPersistentSubscriptionInfo(streamName string, groupName string, options GetPersistentSubscriptionOptions) (*PersistentSubscriptionInfo, error) {
-	body, err := client.httpExecute("GET", fmt.Sprintf("/subscriptions/%s/%s/info", url.PathEscape(streamName), url.PathEscape(groupName)), options.Authenticated, nil)
+func (client *Client) httpGetPersistentSubscriptionInfo(ctx context.Context, streamName string, groupName string, options GetPersistentSubscriptionOptions) (*PersistentSubscriptionInfo, error) {
+	body, err := client.httpExecute(ctx, "GET", fmt.Sprintf("/subscriptions/%s/%s/info", url.PathEscape(streamName), url.PathEscape(groupName)), options.Authenticated, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,7 @@ func (client *Client) httpGetPersistentSubscriptionInfo(streamName string, group
 	return info, nil
 }
 
-func (client *Client) httpReplayParkedMessages(streamName string, groupName string, options ReplayParkedMessagesOptions) error {
+func (client *Client) httpReplayParkedMessages(ctx context.Context, streamName string, groupName string, options ReplayParkedMessagesOptions) error {
 	params := &httpParams{
 		headers: []keyvalue{newKV("content-length", "0")},
 	}
@@ -95,17 +96,17 @@ func (client *Client) httpReplayParkedMessages(streamName string, groupName stri
 	}
 
 	urlStr := fmt.Sprintf("/subscriptions/%s/%s/replayParked", url.PathEscape(streamName), url.PathEscape(groupName))
-	_, err := client.httpExecute("POST", urlStr, options.Authenticated, params)
+	_, err := client.httpExecute(ctx, "POST", urlStr, options.Authenticated, params)
 
 	return err
 }
 
-func (client *Client) httpRestartSubsystem(options RestartPersistentSubscriptionSubsystemOptions) error {
+func (client *Client) httpRestartSubsystem(ctx context.Context, options RestartPersistentSubscriptionSubsystemOptions) error {
 	params := &httpParams{
 		headers: []keyvalue{newKV("content-length", "0")},
 	}
 
-	_, err := client.httpExecute("POST", "/subscriptions/restart", options.Authenticated, params)
+	_, err := client.httpExecute(ctx, "POST", "/subscriptions/restart", options.Authenticated, params)
 
 	return err
 }
@@ -143,13 +144,13 @@ type httpParams struct {
 	headers []keyvalue
 }
 
-func (client *Client) httpExecute(method string, path string, auth *Credentials, params *httpParams) ([]byte, error) {
+func (client *Client) httpExecute(ctx context.Context, method string, path string, auth *Credentials, params *httpParams) ([]byte, error) {
 	baseUrl, err := client.getBaseUrl()
 	if err != nil {
 		return nil, fmt.Errorf("can't get a connection handle: %w", err)
 	}
 
-	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", baseUrl, path), nil)
+	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s%s", baseUrl, path), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +175,7 @@ func (client *Client) httpExecute(method string, path string, auth *Credentials,
 		}
 	}
 
-	creds, err := client.config.resolveRequestCredentials(req.Context(), auth)
+	creds, err := client.config.resolveRequestCredentials(ctx, auth)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve credentials: %w", err)
 	}

--- a/kurrentdb/persistent_subscription_http_client.go
+++ b/kurrentdb/persistent_subscription_http_client.go
@@ -174,20 +174,13 @@ func (client *Client) httpExecute(method string, path string, auth *Credentials,
 		}
 	}
 
-	var creds *Credentials
-	if auth != nil {
-		creds = auth
-	} else {
-		if client.config.Username != "" {
-			creds = &Credentials{
-				Login:    client.config.Username,
-				Password: client.config.Password,
-			}
-		}
+	creds, err := client.config.resolveRequestCredentials(req.Context(), auth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve credentials: %w", err)
 	}
 
-	if creds != nil {
-		req.SetBasicAuth(creds.Login, creds.Password)
+	if header := creds.authorizationHeader(); header != "" {
+		req.Header.Set("Authorization", header)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/oauth/oauth.conf
+++ b/oauth/oauth.conf
@@ -1,0 +1,17 @@
+ReplicationIp: 0.0.0.0
+NodeIp: 0.0.0.0
+
+# Test fixture only - not a production template. DisableIssuerValidation is set
+# because the issuer (https://localhost:8443) differs across the host/container
+# boundary; it must not be used in a real deployment.
+AuthenticationType: oauth
+
+OAuth:
+  Issuer: https://localhost:8443/realms/kurrent
+  Audience: kurrentdb-client
+  ClientId: kurrentdb-client
+  ClientSecret: secret
+  DisableIssuerValidation: true
+
+AuthorizationConfig:
+  RoleClaimType: role

--- a/oauth/realm-export.json
+++ b/oauth/realm-export.json
@@ -1,0 +1,104 @@
+{
+	"realm": "kurrent",
+	"enabled": true,
+	"accessTokenLifespan": 120,
+	"roles": {
+		"realm": [
+			{ "name": "$admins", "composite": false },
+			{ "name": "$ops", "composite": false }
+		]
+	},
+	"clientScopes": [
+		{
+			"name": "profile",
+			"protocol": "openid-connect",
+			"attributes": { "include.in.token.scope": "true" },
+			"protocolMappers": [
+				{
+					"name": "username",
+					"protocol": "openid-connect",
+					"protocolMapper": "oidc-usermodel-property-mapper",
+					"config": {
+						"user.attribute": "username",
+						"claim.name": "preferred_username",
+						"id.token.claim": "true",
+						"access.token.claim": "true",
+						"userinfo.token.claim": "true",
+						"jsonType.label": "String"
+					}
+				}
+			]
+		},
+		{
+			"name": "roles",
+			"description": "Adds realm roles to the access token",
+			"protocol": "openid-connect",
+			"attributes": { "include.in.token.scope": "true" },
+			"protocolMappers": [
+				{
+					"name": "roles",
+					"protocol": "openid-connect",
+					"protocolMapper": "oidc-usermodel-realm-role-mapper",
+					"config": {
+						"claim.name": "role",
+						"multivalued": "true",
+						"id.token.claim": "true",
+						"access.token.claim": "true",
+						"jsonType.label": "String",
+						"userinfo.token.claim": "true"
+					}
+				}
+			]
+		}
+	],
+	"clients": [
+		{
+			"clientId": "kurrentdb-client",
+			"enabled": true,
+			"publicClient": true,
+			"standardFlowEnabled": false,
+			"directAccessGrantsEnabled": true,
+			"defaultClientScopes": ["profile", "roles"],
+			"protocolMappers": [
+				{
+					"name": "audience",
+					"protocol": "openid-connect",
+					"protocolMapper": "oidc-audience-mapper",
+					"config": {
+						"included.client.audience": "kurrentdb-client",
+						"id.token.claim": "false",
+						"access.token.claim": "true"
+					}
+				}
+			]
+		}
+	],
+	"users": [
+		{
+			"username": "admin",
+			"enabled": true,
+			"emailVerified": true,
+			"email": "admin@example.com",
+			"firstName": "Admin",
+			"lastName": "User",
+			"requiredActions": [],
+			"credentials": [
+				{ "type": "password", "value": "changeit", "temporary": false }
+			],
+			"realmRoles": ["$admins"]
+		},
+		{
+			"username": "noroles",
+			"enabled": true,
+			"emailVerified": true,
+			"email": "noroles@example.com",
+			"firstName": "No",
+			"lastName": "Roles",
+			"requiredActions": [],
+			"credentials": [
+				{ "type": "password", "value": "changeit", "temporary": false }
+			],
+			"realmRoles": []
+		}
+	]
+}

--- a/test/auth_oauth_test.go
+++ b/test/auth_oauth_test.go
@@ -1,0 +1,179 @@
+package test
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kurrent-io/KurrentDB-Client-Go/kurrentdb"
+	"github.com/stretchr/testify/suite"
+)
+
+// These tests run against the OAuth stack in docker-compose.oauth.yml
+// (Keycloak + a KurrentDB node configured for OAuth). Bring it up with
+// `make start-oauth` (requires KURRENTDB_LICENSE_KEY); the suite skips when it
+// is not running.
+const (
+	oauthTokenEndpoint  = "https://localhost:8443/realms/kurrent/protocol/openid-connect/token"
+	oauthNodeConnString = "kurrentdb://localhost:2116?tls=true&tlscafile=../certs/ca/ca.crt"
+)
+
+// fetchOAuthToken obtains an access token from Keycloak using the resource
+// owner password grant (the realm enables direct access grants for tests).
+func fetchOAuthToken(username, password string) (string, error) {
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+		// Test-only: Keycloak serves the self-signed test CA. Do not copy this
+		// into non-test code - a real token source must validate the IdP cert.
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+
+	resp, err := httpClient.PostForm(oauthTokenEndpoint, url.Values{
+		"grant_type": {"password"},
+		"client_id":  {"kurrentdb-client"},
+		"username":   {username},
+		"password":   {password},
+		"scope":      {"openid"},
+	})
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, body)
+	}
+
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", err
+	}
+	if out.AccessToken == "" {
+		return "", fmt.Errorf("no access_token in response")
+	}
+
+	return out.AccessToken, nil
+}
+
+// bearerProvider returns a provider that supplies a freshly minted token for
+// the given user on each call.
+func bearerProvider(username, password string) kurrentdb.CredentialsProvider {
+	return func(context.Context) (*kurrentdb.Credentials, error) {
+		token, err := fetchOAuthToken(username, password)
+		if err != nil {
+			return nil, err
+		}
+		return &kurrentdb.Credentials{BearerToken: token}, nil
+	}
+}
+
+func TestOAuthAuthenticationSuite(t *testing.T) {
+	suite.Run(t, new(OAuthAuthTestSuite))
+}
+
+type OAuthAuthTestSuite struct {
+	suite.Suite
+}
+
+// SetupSuite skips the suite unless the whole OAuth stack is up and working:
+// Keycloak issues a token AND the OAuth node accepts it. This guarantees that
+// a failure in the negative tests below is about the credentials under test,
+// not an unavailable or unhealthy stack.
+func (s *OAuthAuthTestSuite) SetupSuite() {
+	token, err := fetchOAuthToken("admin", "changeit")
+	if err != nil {
+		s.T().Skipf("OAuth stack not available (run `make start-oauth`): %v", err)
+	}
+
+	client := s.newClient(staticBearer(token))
+	defer client.Close()
+	if err := s.createSubscription(client, kurrentdb.PersistentStreamSubscriptionOptions{}); err != nil {
+		s.T().Skipf("OAuth node not ready (run `make start-oauth`): %v", err)
+	}
+}
+
+func staticBearer(token string) kurrentdb.CredentialsProvider {
+	return func(context.Context) (*kurrentdb.Credentials, error) {
+		return &kurrentdb.Credentials{BearerToken: token}, nil
+	}
+}
+
+func (s *OAuthAuthTestSuite) newClient(provider kurrentdb.CredentialsProvider) *kurrentdb.Client {
+	config, err := kurrentdb.ParseConnectionString(oauthNodeConnString)
+	s.Require().NoError(err, "Failed to parse connection string")
+	config.CredentialsProvider = provider
+
+	client, err := kurrentdb.NewClient(config)
+	s.Require().NoError(err, "Failed to create KurrentDB client")
+
+	return client
+}
+
+// createSubscription performs an admin-authorized operation, used as the probe
+// for whether authentication and authorization succeeded.
+func (s *OAuthAuthTestSuite) createSubscription(client *kurrentdb.Client, opts kurrentdb.PersistentStreamSubscriptionOptions) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	return client.CreatePersistentSubscription(ctx, uuid.NewString(), uuid.NewString(), opts)
+}
+
+func (s *OAuthAuthTestSuite) TestProviderWithValidTokenSucceeds() {
+	client := s.newClient(bearerProvider("admin", "changeit"))
+	defer client.Close()
+
+	err := s.createSubscription(client, kurrentdb.PersistentStreamSubscriptionOptions{})
+	s.NoError(err, "a valid bearer token from the provider should authenticate")
+}
+
+func (s *OAuthAuthTestSuite) TestPerCallBearerTokenSucceeds() {
+	token, err := fetchOAuthToken("admin", "changeit")
+	s.Require().NoError(err)
+
+	client := s.newClient(nil)
+	defer client.Close()
+
+	err = s.createSubscription(client, kurrentdb.PersistentStreamSubscriptionOptions{
+		Authenticated: &kurrentdb.Credentials{BearerToken: token},
+	})
+	s.NoError(err, "a valid per-call bearer token should authenticate")
+}
+
+func (s *OAuthAuthTestSuite) TestValidTokenWithoutRequiredRoleIsDenied() {
+	// The "noroles" user authenticates but lacks the role to manage persistent
+	// subscriptions: the token is accepted (authentication) but the operation
+	// is rejected (authorization).
+	client := s.newClient(bearerProvider("noroles", "changeit"))
+	defer client.Close()
+
+	err := s.createSubscription(client, kurrentdb.PersistentStreamSubscriptionOptions{})
+	kErr, _ := kurrentdb.FromError(err)
+	s.Require().NotNil(kErr)
+	s.True(kErr.IsErrorCode(kurrentdb.ErrorCodeAccessDenied), "expected access denied, got %v", err)
+}
+
+func (s *OAuthAuthTestSuite) TestProviderErrorFails() {
+	client := s.newClient(func(context.Context) (*kurrentdb.Credentials, error) {
+		return nil, fmt.Errorf("token source unavailable")
+	})
+	defer client.Close()
+
+	err := s.createSubscription(client, kurrentdb.PersistentStreamSubscriptionOptions{})
+	s.Require().Error(err)
+	// The provider's error propagates through to the caller, proving the failure
+	// originated in credential resolution rather than the transport.
+	s.ErrorContains(err, "token source unavailable")
+}


### PR DESCRIPTION
Adds OAuth/JWT bearer-token authentication to the client, matching the .NET and Node clients, plus an end-to-end OAuth test stack.

- **`Credentials` / `CredentialsProvider`** — `Credentials` gains a `BearerToken`, and a new `Configuration.CredentialsProvider` (a named func type) is invoked per RPC, so a refresh-aware OAuth/OIDC token source rotates transparently across reconnects. Bearer tokens are supplied programmatically, not via the connection string.
- **Resolution precedence** — per-call credentials > provider > static username/password, shared by the gRPC and HTTP-fallback paths. Credentials are never attached over an insecure (`DisableTLS`) channel.
- **HTTP persistent-subscription path** — now resolves credentials through the shared path: it supports bearer tokens and honours `DisableTLS`, so it no longer sends Basic credentials over an insecure connection (matching the gRPC path).
- **Unit tests** — header rendering, per-RPC re-resolution, error propagation, precedence, and the insecure-channel guard.
- **OAuth test stack** — `docker-compose.oauth.yml` (Keycloak plus an OAuth-configured node), a Keycloak realm, `make start-oauth`/`stop-oauth`, and `test/auth_oauth_test.go`. It is separate from the default suite because OAuth is a licensed feature: the suite skips when the stack is not running and is not part of the default CI matrix. Enabling it in CI needs a license-key secret, a plugin-capable image, and a matrix entry.
