### PR TITLE
Fix nil-deref panics when listing projections

### DIFF
--- a/kurrentdb/projection_client.go
+++ b/kurrentdb/projection_client.go
@@ -486,7 +486,7 @@ func (client *ProjectionClient) listInternal(
 
 		details := item.GetDetails()
 		if details == nil {
-			continue
+			return nil, &Error{code: ErrorCodeInternalServer, err: fmt.Errorf("statistics response is missing details")}
 		}
 
 		proj := ProjectionStatus{

--- a/kurrentdb/projection_client.go
+++ b/kurrentdb/projection_client.go
@@ -423,6 +423,10 @@ func (client *ProjectionClient) GetStatus(
 		return nil, err
 	}
 
+	if len(projs) == 0 {
+		return nil, &Error{code: ErrorCodeResourceNotFound, err: fmt.Errorf("projection '%s' is not found", name)}
+	}
+
 	return &projs[0], nil
 }
 
@@ -462,6 +466,9 @@ func (client *ProjectionClient) listInternal(
 	stream, err := projClient.Statistics(ctx, &projections.StatisticsReq{
 		Options: &options,
 	}, callOptions...)
+	if err != nil {
+		return nil, client.inner.grpcClient.handleError(handle, trailers, err)
+	}
 
 	var projs []ProjectionStatus
 
@@ -477,26 +484,31 @@ func (client *ProjectionClient) listInternal(
 			return projs, nil
 		}
 
+		details := item.GetDetails()
+		if details == nil {
+			continue
+		}
+
 		proj := ProjectionStatus{
-			CoreProcessingTime:                 item.Details.CoreProcessingTime,
-			Version:                            item.Details.Version,
-			Epoch:                              item.Details.Epoch,
-			EffectiveName:                      item.Details.EffectiveName,
-			WritesInProgress:                   item.Details.WritesInProgress,
-			ReadsInProgress:                    item.Details.ReadsInProgress,
-			PartitionsCached:                   item.Details.PartitionsCached,
-			Status:                             item.Details.Status,
-			StateReason:                        item.Details.StateReason,
-			Name:                               item.Details.Name,
-			Mode:                               item.Details.Mode,
-			Position:                           item.Details.Position,
-			Progress:                           item.Details.Progress,
-			LastCheckpoint:                     item.Details.LastCheckpoint,
-			EventsProcessedAfterRestart:        item.Details.EventsProcessedAfterRestart,
-			CheckpointStatus:                   item.Details.CheckpointStatus,
-			BufferedEvents:                     item.Details.BufferedEvents,
-			WritePendingEventsBeforeCheckpoint: item.Details.WritePendingEventsBeforeCheckpoint,
-			WritePendingEventsAfterCheckpoint:  item.Details.WritePendingEventsAfterCheckpoint,
+			CoreProcessingTime:                 details.CoreProcessingTime,
+			Version:                            details.Version,
+			Epoch:                              details.Epoch,
+			EffectiveName:                      details.EffectiveName,
+			WritesInProgress:                   details.WritesInProgress,
+			ReadsInProgress:                    details.ReadsInProgress,
+			PartitionsCached:                   details.PartitionsCached,
+			Status:                             details.Status,
+			StateReason:                        details.StateReason,
+			Name:                               details.Name,
+			Mode:                               details.Mode,
+			Position:                           details.Position,
+			Progress:                           details.Progress,
+			LastCheckpoint:                     details.LastCheckpoint,
+			EventsProcessedAfterRestart:        details.EventsProcessedAfterRestart,
+			CheckpointStatus:                   details.CheckpointStatus,
+			BufferedEvents:                     details.BufferedEvents,
+			WritePendingEventsBeforeCheckpoint: details.WritePendingEventsBeforeCheckpoint,
+			WritePendingEventsAfterCheckpoint:  details.WritePendingEventsAfterCheckpoint,
 		}
 
 		projs = append(projs, proj)


### PR DESCRIPTION
Fixes three nil-deref panics in the projections client's list path.

- **`listInternal` unchecked stream-open error** — `projClient.Statistics(...)` returns `(nil, err)` on a `NewStream`/`SendMsg`/`CloseSend` failure, but the error was assigned and never checked, so a transient dial/auth failure ran `stream.Recv()` on a nil stream and panicked. Now returned via `handleError`, matching the in-loop error handling.
- **`listInternal` nil `Details`** — each streamed item's `Details` (a `*StatisticsResp_Details`, proto `omitempty`) was dereferenced ~19 times with no guard. Read it once via the nil-safe `GetDetails()` accessor and skip items with no details.
- **`GetStatus` empty result** — returned `&projs[0]` unconditionally, an index-out-of-range panic when a named lookup streamed nothing (now reachable via the skip above, and already possible if the server streamed zero items before EOF). Returns `ErrorCodeResourceNotFound` instead.

No new test: the projection suite runs against a live secure node and can't produce a nil `Details` or empty-stream response without a fake `ProjectionsClient` seam the client doesn't currently expose.
